### PR TITLE
Update to "identifier" functionality

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -398,7 +398,7 @@
     {
       "identifier": {
         "identifier": "https://www.ncbi.nlm.nih.gov/taxonomy/10090",
-		"identifierSource": NCBI Taxonomy Database"
+		"identifierSource": "NCBI Taxonomy Database"
       },
       "name":"Mus musculus"
     }

--- a/DATS.json
+++ b/DATS.json
@@ -397,8 +397,8 @@
   "isAbout": [
     {
       "identifier": {
-        "identifier": "10090",
-        "identifierSource":"https://www.ncbi.nlm.nih.gov/taxonomy/10090"
+        "identifier": "https://www.ncbi.nlm.nih.gov/taxonomy/10090",
+		"identifierSource": NCBI Taxonomy Database"
       },
       "name":"Mus musculus"
     }


### PR DESCRIPTION
This PR corrects the usage of identifier and `identifierSource` in the taxonomic data under the `isAbout` entry in `DATS.json` in keeping with CONP-PCNO/conp-dataset#712.